### PR TITLE
Update installation instructions to use a separate folder

### DIFF
--- a/GetStarted.md
+++ b/GetStarted.md
@@ -3,24 +3,32 @@ lang: en-US
 title: Installation
 ---
 
-## Manual Installation
+# INSTALL
+Installation requires that you own a PC version of AmongUs on Steam, Epic, or Itch. 
 
-1. Click [here](https://github.com/Loonie-Toons/TownOfHost-ReEdited/releases) and download the latest release.
+## Step 1
+Download the latest full Release of TOHRE [here](https://github.com/Loonie-Toons/TownOfHost-ReEdited/releases). You only need the main zip such as "TOHE.v2.5.0.zip", not the source code files.
+ 
+## Step 2
+Once the download is complete, unzip it into the location of your choice. Example: C:\TOHRE
+  
+## Step 3
+Locate your AmongUs install. For example, if you own the game on Steam, you can find this by right clicking on the game in your library, selecting "Manage", and finally selecting "Browse local files."
+![image](https://github.com/0xDrMoe/TOHRE-Code/assets/6992162/a760213d-5bc4-44cc-9bfc-588667b735ac)
 
-2. If you use Steam, please operate according to the img botton, the folder that pops up is the root directory of the game.
+## Step 4
+Select all of the files in your AmongUs installation and copy them to the folder that now has the files from the TOHRE release. The folder should now look something like this:
+![image](https://github.com/0xDrMoe/TOHRE-Code/assets/6992162/44e624d4-786e-4270-a607-2a407351234d)
 
-   ![SteamGetFolder](./images/SteamGetFolder.png)
+## Step 5
+Within the TOHRE folder, run Among Us.exe. The first time running it may take some time while the mod sets up its files. If you see a black screen, just wait a couple minutes. Once it finishes loading, you should get a popup with TOHRE news. If you do not see anything about TOHE, double check that your files are all in the same folder.
 
-3. If you use Epic, please manually find the root directory of the game, there are specific tutorials online.
+## Finish
+You have now installed TOHRE! All that remains is to start up a private lobby and customize your settings.
 
-4. After finding the root directory of the game, open the .zip file just downloaded, and drag all the files inside into the root directory of the game. ([Click to view the demo](https://npm.elemecdn.com/tohe-doc-resources@1.0.2/MoveFile.gif))
+# Update
+Keep an eye on the [releases page](https://github.com/Loonie-Toons/TownOfHost-ReEdited/releases) for new releases. If a new version is released, all you'll usually need to do is repeat steps 1-2 above, unzipping into the same folder where you already have it installed and letting it overwrite. If it says it requires a newer version of Among Us, repeat steps 3-5 as well after making sure your base game is up to date.
 
-5. Now you can start the game on Steam or Epic. It takes time to download the dependent files when starting the mod for the first time, please wait patiently for the game to pop up.
-
-
-## Use Mod Manager (OUT OF DATE)
-
-1. Click [here](https://goodloss.fr/latest) and download the Mod Manager.
-2. Run Mod Manager & Select `Mods` > `Other Mods` > `Town Of Host Edited` > `Download`.
-
-**![ModManager](./images/ModManager.webp)**
+# Canary Versions
+If you would like to test the newest versions of TOHRE ebfore they're officially released, you can download the latest canary version from the [official TOHRE discord](https://discord.gg/tohe). These versions will just be a TOHE.dll file, which you will place in your .\BepInEx\plugins folder, for example "C:\TOHRE\BepInEx\plugins", and overwrite the old one. You must have already installed the latest main release before you can use a canary version.
+ 


### PR DESCRIPTION
Installing the mod into its own folder is current best practices, as installing directly into the game installation folder can cause issues if the game updates and does not leave the user with the ability to join games on a vanilla client.

I've also expanded the instructions to include updating and using canary versions, and removed the instructions for ModManager as they no longer apply.